### PR TITLE
Add activate/deactivate scripts

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/migrations/root_base6246.yaml
+++ b/.ci_support/migrations/root_base6246.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  check_solvable: false
-migrator_ts: 1630722380.715523
-root_base:
-- 6.24.6

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/recipe/activate.csh
+++ b/recipe/activate.csh
@@ -1,0 +1,12 @@
+#!/usr/bin/env csh
+#
+# Configure a conda environment for Omicron
+#
+
+# backup the environment's current setting
+if ($?OMICRON_HTML) then
+	setenv CONDA_BACKUP_OMICRON_HTML "${OMICRON_HTML}"
+endif
+
+# set the variable
+setenv OMICRON_HTML "${CONDA_PREFIX}/share/omicron/html"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Configure a conda environment for Omicron
+#
+
+# preserve the user's existing setting
+if [ ! -z "${OMICRON_HTML+x}" ]; then
+	export CONDA_BACKUP_OMICRON_HTML="${OMICRON_HTML}"
+fi
+
+# set the variable
+export OMICRON_HTML="${CONDA_PREFIX}/share/omicron/html"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,9 +23,10 @@ cmake --build . --parallel ${CPU_COUNT} --verbose --target install
 
 # install activate/deactivate scripts
 for action in activate deactivate; do
-	mkdir -pv ${PREFIX}/etc/conda/${action}.d
+	mkdir -p ${PREFIX}/etc/conda/${action}.d
 	for ext in sh csh; do
-		echo "-- Installing: ${action}.${ext}"
-		cp -v "${RECIPE_DIR}/${action}.${ext}" "${PREFIX}/etc/conda/${action}.d/activate-${PKG_NAME}.${ext}"
+		_target="${PREFIX}/etc/conda/${action}.d/activate-${PKG_NAME}.${ext}"
+		echo "-- Installing: ${_target}"
+		cp "${RECIPE_DIR}/${action}.${ext}" "${_target}"
 	done
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,3 +20,12 @@ ctest --parallel ${CPU_COUNT} --verbose
 
 # install
 cmake --build . --parallel ${CPU_COUNT} --verbose --target install
+
+# install activate/deactivate scripts
+for action in activate deactivate; do
+	mkdir -pv ${PREFIX}/etc/conda/${action}.d
+	for ext in sh csh; do
+		echo "-- Installing: ${action}.${ext}"
+		cp -v "${RECIPE_DIR}/${action}.${ext}" "${PREFIX}/etc/conda/${action}.d/activate-${PKG_NAME}.${ext}"
+	done
+done

--- a/recipe/deactivate.csh
+++ b/recipe/deactivate.csh
@@ -1,0 +1,11 @@
+#!/usr/bin/env csh
+#
+# Deconfigure a conda environment for Omicron
+#
+
+if ($?OMICRON_HTML) then
+	setenv OMICRON_HTML "$CONDA_BACKUP_OMICRON_HTML"
+	unsetenv CONDA_BACKUP_OMICRON_HTML
+else
+	unsetenv OMICRON_HTML
+endif

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# De-configure a conda environment for Omicron
+#
+
+# restore from backup
+if [ ! -z "${CONDA_BACKUP_OMICRON_HTML}" ]; then
+	export OMICRON_HTML="${CONDA_BACKUP_OMICRON_HTML}"
+	unset CONDA_BACKUP_OMICRON_HTML
+# no backup, just unset
+else
+	unset OMICRON_HTML
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 2
+  number: 3
   skip: true  # [win]
 
 requirements:
@@ -48,6 +48,8 @@ test:
     - for omitest in ${PREFIX}/sbin/omicron-test-*; do ${omitest}; done  # [not osx]
     # check pkg-config
     - pkg-config --print-errors --exact-version {{ version }} {{ name|lower }}
+    # check activate variables
+    - test "${OMICRON_HTML}" == "${PREFIX}/share/omicron/html"  # [unix]
 
 about:
   home: https://virgo.docs.ligo.org/virgoapp/{{ name }}/


### PR DESCRIPTION
This MR adds `{de}activate-omicron.{sh,csh}` scripts to set/unset the `OMICRON_HTML` variable.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
